### PR TITLE
Store status, handle cycle reset for long break

### DIFF
--- a/background.js
+++ b/background.js
@@ -127,14 +127,17 @@ function completeTimer() {
       ? 'long break'
       : 'break'
     : 'active';
-  chrome.notifications.create('my-notification',{
-    type: 'basic',
-    iconUrl: 'stay_hydrated.png',
-    title: 'Time to Hydrate',
-    message: 
-      "Notification type: " + notifyText,
-    buttons: [{ title: 'Keep it Flowing.' }],
-    priority: 0
+  // Store completion info (lastStatus, currentCycle), then notify
+  saveCompletion().then(() => {
+    chrome.notifications.create('my-notification',{
+      type: 'basic',
+      iconUrl: 'stay_hydrated.png',
+      title: 'Time to Hydrate',
+      message: 
+        "Notification type: " + notifyText,
+      buttons: [{ title: 'Keep it Flowing.' }],
+      priority: 0
+    });
   });
   // TODO: Open browser tab with info
   // TODO: store today's pomodoro history
@@ -169,6 +172,7 @@ function runEvent(event) {
         } else {
           // Otherwise, heartbeat will continue!
           // Update badge with # of minutes
+          // TODO: Account for drift, shorten heartbeat to better hit next minute mark
           chrome.action.setBadgeText({ text: getBadgeTextFromSeconds(diff / 1000)});
         }
       } else {
@@ -188,7 +192,8 @@ function runEvent(event) {
   }
 }
 
-// Settings for debugging: `await chrome.storage.sync.set({'cyclePeriod': 2, 'activeTime': 60, 'breakTime': 30, 'longBreakTime': 39})`
+// Settings for debugging:
+// `await chrome.storage.sync.set({'cyclePeriod': 2, 'activeTime': 60, 'breakTime': 30, 'longBreakTime': 39})`
 function getDefault(setting) {
   switch (setting) {
     case 'cyclePeriod':
@@ -236,26 +241,27 @@ async function loadStatus(){
   // First load our synced settings
   // Then load Pomodoro Cycle state and save history if we've rolled to a new day
   let cycleSetup = settingsSetup().then(() => {
-  return chrome.storage.local.get(['store-pause-completed', 'last-heartbeat'])
+  return chrome.storage.local.get(['store-completed', 'last-heartbeat'])
     .then((result) => {
       // TODO save history and use last-heartbeat to roll over a new day
       // TODO handle cyclePeriod edits that make currentCycle > cyclePeriod (oops!)
-      currentCycle = result['store-pause-completed'] || 0;
-      return chrome.storage.local.remove(['store-pause-completed']);
+      currentCycle = result['store-completed'] || 0;
+      return chrome.storage.local.remove(['store-completed']);
     });
   });
 
   loading = cycleSetup.then(() =>
-    chrome.storage.local.get(['store-pause-leftover', 'store-pause-status'])
+    chrome.storage.local.get(['store-pause-leftover', 'store-pause-status','store-asleep-last-status'])
     .then(result => {
       console.log('Result received: %o', result)
       const leftover = result['store-pause-leftover'];
       if (!leftover) {
         // We're asleep, resumed without a stored pause
-        console.log('Resuming as if asleep')
+        console.log('Resuming as if asleep, with lastStatus: %s',result['store-asleep-last-status'])
         localStatus = 'asleep'
-        // Don't set lastStatus, that defaulting should only run for icon-click event
-        return; // Nothing stored, nothing to remove!
+        // Setting lastStatus to handle resume from inactivity
+        lastStatus=result['store-asleep-last-status']
+        return chrome.storage.local.remove(['store-asleep-last-status']);
       } else {
         console.log('Resuming as if paused')
         localStatus = 'paused'
@@ -267,6 +273,28 @@ async function loadStatus(){
       }));
   await loading;
   loading = null;
+}
+
+// Only store completion info (lastStatus, currentCycle already incremented), then stop heartbeat
+async function saveCompletion() {
+  // If you change cyclePeriod during a 'break',
+  // status check here prevents cycle reset after that break (could be weird...)
+  if (lastStatus=='active' && isLongBreak()) {
+    // Reset `currentCylce`, store rest to Pomodoro History
+    // TODO: Actually store off... Need to promise chain
+    console.log('Storing cycles: %s', currentCycle);
+    currentCycle=0;
+  }
+  loading = 
+    chrome.storage.local.set({
+      'store-asleep-last-status': lastStatus,
+      'store-completed': currentCycle
+    })
+    .then(stopHeartbeat);
+  await loading;
+  loading = null;
+  // TODO: for above History, maybe register a promise here but don't await it?
+  // TODO: When to store History for users without long breaks configured?
 }
 
 // Clears local status, stops heartbeat, store cycle, to allow SW to go inactive
@@ -283,15 +311,13 @@ async function saveStatus() {
     await loading;
     return;
   }
-  // TODON'T: No need to store Pomodoro History here
-  // Just make sure the history page can read today's count
   // Save the stuff + clear local status
   console.log('Storing time left before "%s" is over: %s (completed %s)', lastStatus, nextNotify - new Date(), currentCycle)
   loading = 
     chrome.storage.local.set({
       'store-pause-leftover': nextNotify - new Date(),
       'store-pause-status': lastStatus,
-      'store-pause-completed': currentCycle
+      'store-completed': currentCycle
     })
     .then(stopHeartbeat);
   await loading;


### PR DESCRIPTION
Fix to #1, by storing off an `asleep-last-status` variable whenever we complete a heartbeat

Also scaffolded out storing Pomodoro History in this same function. Seems like the best time to.

For that, showed how to reset your current cycle whenever you hit a long break, and is resilient to someone changing the cyclePeriod setting while you have a timer going :)